### PR TITLE
Updated the Issues link at the end of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ This dynamic visualization allows the user to customize some different views and
 
 ## 3. Contributing to this visualization code
 If you wish to improve or enhance this code or if you find errors or bugs, please consider the following ways to contribute to this project.
-* Browse the repository [Issues](issues) for known areas that need attention.
-* Submit questions or suggestions by submitting a new issue in the repository [Issues](issues).
+* Browse the repository [Issues](https://github.com/OpenSourceEcon/DJIA_NormPeakPlot/issues) for known areas that need attention.
+* Submit questions or suggestions by submitting a new issue in the repository [Issues](https://github.com/OpenSourceEcon/DJIA_NormPeakPlot/issues).
 * Submit a pull request with your proposed changes.


### PR DESCRIPTION
This PR updates the "Issues" links at the end of the `README.md`. I had initially tried to use relative links in the markdown, but that is not supported for the Issues page as far as I can determine. So I just put in the full path.